### PR TITLE
Fix missing UI components

### DIFF
--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -1,0 +1,16 @@
+import { Linking, Pressable, PressableProps } from 'react-native';
+
+interface Props extends PressableProps {
+  href: string;
+}
+
+export function ExternalLink({ href, children, ...props }: Props) {
+  const handlePress = () => {
+    Linking.openURL(href).catch(() => {});
+  };
+  return (
+    <Pressable onPress={handlePress} {...props}>
+      {children}
+    </Pressable>
+  );
+}

--- a/components/HelloWave.tsx
+++ b/components/HelloWave.tsx
@@ -1,0 +1,5 @@
+import { Text } from 'react-native';
+
+export function HelloWave() {
+  return <Text accessibilityRole="text">👋</Text>;
+}

--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -1,0 +1,16 @@
+import { Text, TextProps, useColorScheme } from 'react-native';
+
+type Props = TextProps & { type?: 'title' | 'subtitle' | 'link' };
+
+export function ThemedText({ type, style, ...rest }: Props) {
+  const colorScheme = useColorScheme();
+  let extraStyle = {} as any;
+  if (type === 'title') {
+    extraStyle = { fontSize: 20, fontWeight: 'bold' };
+  } else if (type === 'subtitle') {
+    extraStyle = { fontSize: 16, fontWeight: '600' };
+  } else if (type === 'link') {
+    extraStyle = { color: colorScheme === 'dark' ? '#4B91F7' : '#1E3A8A' };
+  }
+  return <Text style={[extraStyle, style]} {...rest} />;
+}

--- a/components/ThemedView.tsx
+++ b/components/ThemedView.tsx
@@ -1,0 +1,9 @@
+import { View, ViewProps, useColorScheme } from 'react-native';
+
+type Props = ViewProps;
+
+export function ThemedView({ style, ...rest }: Props) {
+  const colorScheme = useColorScheme();
+  const backgroundColor = colorScheme === 'dark' ? '#000' : '#fff';
+  return <View style={[{ backgroundColor }, style]} {...rest} />;
+}


### PR DESCRIPTION
## Summary
- add basic implementations for `HelloWave`, `ThemedText`, `ThemedView` and `ExternalLink`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5c25948483249f0859f89f89f515